### PR TITLE
Feat: add login handler

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment: 
      - DB_URL=postgres://postgres:1234@db:5432/desafio?sslmode=disable
      - API_PORT=:3000
+     - EXP_TIME=5m
     networks:
       - application
   db: 

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 	loginStorage := login.NewStorage(dbPool)
 	loginUseCase, err := login_usecase.NewUseCase(accountRepository, loginStorage, apiConfig.TokenSecret, apiConfig.ExpTime)
 	if err != nil {
-		log.WithError(err).Fatal("error while parsing duration")
+		log.WithError(err).Error("error while parsing duration")
 	}
 	loginHandler := login_handler.NewHandler(loginUseCase, log)
 

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 	loginStorage := login.NewStorage(dbPool)
 	loginUseCase, err := login_usecase.NewUseCase(accountRepository, loginStorage, apiConfig.TokenSecret, apiConfig.ExpTime)
 	if err != nil {
-		log.WithError(err).Error("error while parsing duration")
+		log.WithError(err).Error("error while parsing the duration")
 	}
 	loginHandler := login_handler.NewHandler(loginUseCase, log)
 

--- a/pkg/domain/login/use_case_mock.go
+++ b/pkg/domain/login/use_case_mock.go
@@ -1,0 +1,12 @@
+package login
+
+import "context"
+
+type UseCaseMock struct {
+	Token string
+	Error error
+}
+
+func (m *UseCaseMock) Login(ctx context.Context, cpf, accountSecret string) (string, error) {
+	return m.Token, m.Error
+}

--- a/pkg/domain/login/usecase.go
+++ b/pkg/domain/login/usecase.go
@@ -8,6 +8,9 @@ import (
 var (
 	ErrTokenNotFound = errors.New("token not found")
 	ErrInvalidToken  = errors.New("invalid token found")
+	ErrEmptySecret   = errors.New("secret informed is blanc")
+	ErrInvalidCPF    = errors.New("cpf informed is invalid")
+	ErrInvalidSecret = errors.New("secret informed is incorrect")
 )
 
 type UseCase interface {

--- a/pkg/domain/login/usecase.go
+++ b/pkg/domain/login/usecase.go
@@ -11,7 +11,7 @@ var (
 	ErrEmptySecret   = errors.New("secret informed is blanc")
 	ErrInvalidCPF    = errors.New("cpf informed is invalid")
 	ErrInvalidSecret = errors.New("secret informed is incorrect")
-	ErrInvalidCredetials= errors.New("invalid credentials")
+	ErrInvalidCredentials= errors.New("invalid credentials")
 )
 
 type UseCase interface {

--- a/pkg/domain/login/usecase.go
+++ b/pkg/domain/login/usecase.go
@@ -11,6 +11,7 @@ var (
 	ErrEmptySecret   = errors.New("secret informed is blanc")
 	ErrInvalidCPF    = errors.New("cpf informed is invalid")
 	ErrInvalidSecret = errors.New("secret informed is incorrect")
+	ErrInvalidCredetials= errors.New("invalid credentials")
 )
 
 type UseCase interface {

--- a/pkg/domain/login/usecase.go
+++ b/pkg/domain/login/usecase.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"context"
 	"errors"
 )
 
@@ -8,3 +9,7 @@ var (
 	ErrTokenNotFound = errors.New("token not found")
 	ErrInvalidToken  = errors.New("invalid token found")
 )
+
+type UseCase interface {
+	Login(ctx context.Context, cpf, accountSecret string) (string, error)
+}

--- a/pkg/domain/login/usecase.go
+++ b/pkg/domain/login/usecase.go
@@ -8,7 +8,7 @@ import (
 var (
 	ErrTokenNotFound = errors.New("token not found")
 	ErrInvalidToken  = errors.New("invalid token found")
-	ErrEmptySecret   = errors.New("secret informed is blanc")
+	ErrEmptySecret   = errors.New("empty secret was informed")
 	ErrInvalidCPF    = errors.New("cpf informed is invalid")
 	ErrInvalidSecret = errors.New("secret informed is incorrect")
 	ErrInvalidCredentials= errors.New("invalid credentials")

--- a/pkg/domain/login/usecases/login.go
+++ b/pkg/domain/login/usecases/login.go
@@ -12,30 +12,30 @@ import (
 
 func (l LoginUseCase) Login(ctx context.Context, cpf, accountSecret string) (string, error) {
 	if len(accountSecret) == 0 {
-		return "", fmt.Errorf("error while validating secret informed: %w", login.ErrEmptySecret)
+		return "", fmt.Errorf("error while validating the secret informed: %w", login.ErrEmptySecret)
 	}
 	if len(cpf) != 11 {
-		return "", fmt.Errorf("error while validanting cpf informed: %w", login.ErrInvalidCPF)
+		return "", fmt.Errorf("error while validating the cpf informed: %w", login.ErrInvalidCPF)
 	}
 	account, err := l.AccountStorage.GetByCPF(ctx, cpf)
 	if err != nil {
-		return "", fmt.Errorf("error while getting account by cpf: %w", err)
+		return "", fmt.Errorf("error while getting the account by cpf: %w", err)
 	}
 	err = bcrypt.CompareHashAndPassword([]byte(account.Secret), []byte(accountSecret))
 	if err != nil {
-		return "", fmt.Errorf("error while comparing secret informed with stored: %w", login.ErrInvalidSecret)
+		return "", fmt.Errorf("error while comparing the secret informed with stored: %w", login.ErrInvalidSecret)
 	}
 
 	claim := entities.NewClaim(account.ID, l.expTime)
 
 	token, err := GenerateJWT(claim, l.tokenSecret)
 	if err != nil {
-		return "", fmt.Errorf("error while generating token: %w", err)
+		return "", fmt.Errorf("error while generating the token: %w", err)
 	}
 
 	err = l.LoginRepository.Insert(ctx, claim, token)
 	if err != nil {
-		return "", fmt.Errorf("error while inserting token: %w", err)
+		return "", fmt.Errorf("error while inserting the token: %w", err)
 	}
 
 	return token, nil

--- a/pkg/domain/login/usecases/login.go
+++ b/pkg/domain/login/usecases/login.go
@@ -5,18 +5,25 @@ import (
 	"fmt"
 
 	"github.com/daniel1sender/Desafio-API/pkg/domain/entities"
+	"github.com/daniel1sender/Desafio-API/pkg/domain/login"
 	jwt "github.com/golang-jwt/jwt/v4"
 	"golang.org/x/crypto/bcrypt"
 )
 
 func (l LoginUseCase) Login(ctx context.Context, cpf, accountSecret string) (string, error) {
+	if len(accountSecret) == 0 {
+		return "", fmt.Errorf("error while validating secret informed: %w", login.ErrEmptySecret)
+	}
+	if len(cpf) != 11 {
+		return "", fmt.Errorf("error while validanting cpf informed: %w", login.ErrInvalidCPF)
+	}
 	account, err := l.AccountStorage.GetByCPF(ctx, cpf)
 	if err != nil {
 		return "", fmt.Errorf("error while getting account by cpf: %w", err)
 	}
 	err = bcrypt.CompareHashAndPassword([]byte(account.Secret), []byte(accountSecret))
 	if err != nil {
-		return "", fmt.Errorf("error while validating secret: %w", err)
+		return "", fmt.Errorf("error while comparing secret informed with stored: %w", login.ErrInvalidSecret)
 	}
 
 	claim := entities.NewClaim(account.ID, l.expTime)

--- a/pkg/domain/login/usecases/login_test.go
+++ b/pkg/domain/login/usecases/login_test.go
@@ -31,6 +31,7 @@ func TestLoginUseCase_Login(t *testing.T) {
 		balance := 10
 		account, _ := entities.NewAccount(name, cpf, accountSecret, balance)
 		accountRepository.Upsert(ctx, account)
+
 		tokenString, err := useCase.Login(ctx, account.CPF, accountSecret)
 		assert.Nil(err)
 		assert.NotEmpty(tokenString)
@@ -44,6 +45,7 @@ func TestLoginUseCase_Login(t *testing.T) {
 		accountSecret := "123"
 		balance := 10
 		account, _ := entities.NewAccount(name, cpf, accountSecret, balance)
+		
 		tokenString, err := useCase.Login(ctx, account.CPF, accountSecret)
 		assert.True(errors.Is(err, accounts_usecases.ErrAccountNotFound))
 		assert.Empty(tokenString)

--- a/pkg/gateways/http/login/handler.go
+++ b/pkg/gateways/http/login/handler.go
@@ -1,0 +1,18 @@
+package login
+
+import (
+	"github.com/daniel1sender/Desafio-API/pkg/domain/login"
+	"github.com/sirupsen/logrus"
+)
+
+type Handler struct {
+	UseCase login.UseCase
+	logger  *logrus.Entry
+}
+
+func NewHandler(useCase login.UseCase, logger *logrus.Entry) Handler {
+	return Handler{
+		UseCase: useCase,
+		logger:  logger,
+	}
+}

--- a/pkg/gateways/http/login/login.go
+++ b/pkg/gateways/http/login/login.go
@@ -44,7 +44,7 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 		log.WithError(err).Error("login request failed")
 		switch {
 		case errors.Is(err, accounts.ErrAccountNotFound):
-			response := server_http.Error{Reason: login.ErrInvalidCredetials.Error()}
+			response := server_http.Error{Reason: login.ErrInvalidCredentials.Error()}
 			w.WriteHeader(http.StatusNotFound)
 			json.NewEncoder(w).Encode(response)
 		case errors.Is(err, login.ErrEmptySecret):

--- a/pkg/gateways/http/login/login.go
+++ b/pkg/gateways/http/login/login.go
@@ -42,7 +42,7 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 		log.WithError(err).Error("login request failed")
 		switch {
 		case errors.Is(err, accounts.ErrAccountNotFound):
-			response := server_http.Error{Reason: accounts.ErrAccountNotFound.Error()}
+			response := server_http.Error{Reason: login.ErrInvalidCredetials.Error()}
 			w.WriteHeader(http.StatusNotFound)
 			json.NewEncoder(w).Encode(response)
 		case errors.Is(err, login.ErrEmptySecret):

--- a/pkg/gateways/http/login/login.go
+++ b/pkg/gateways/http/login/login.go
@@ -26,6 +26,7 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 		"route":  r.URL.Path,
 		"method": r.Method,
 	}).Info("login attempt realized")
+
 	var request Request
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
@@ -36,6 +37,7 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(response)
 		return
 	}
+
 	w.Header().Add("Content-Type", server_http.JSONContentType)
 	token, err := h.UseCase.Login(r.Context(), request.Cpf, request.Secret)
 	if err != nil {
@@ -64,6 +66,7 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	
 	response := Response{Token: token}
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(response)

--- a/pkg/gateways/http/login/login.go
+++ b/pkg/gateways/http/login/login.go
@@ -43,9 +43,9 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.WithError(err).Error("login request failed")
 		switch {
-		case errors.Is(err, accounts.ErrAccountNotFound):
+		case errors.Is(err, accounts.ErrAccountNotFound), errors.Is(err, login.ErrInvalidSecret):
 			response := server_http.Error{Reason: login.ErrInvalidCredentials.Error()}
-			w.WriteHeader(http.StatusNotFound)
+			w.WriteHeader(http.StatusForbidden)
 			json.NewEncoder(w).Encode(response)
 		case errors.Is(err, login.ErrEmptySecret):
 			response := server_http.Error{Reason: login.ErrEmptySecret.Error()}
@@ -55,10 +55,6 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 			response := server_http.Error{Reason: login.ErrInvalidCPF.Error()}
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(response)
-		case errors.Is(err, login.ErrInvalidSecret):
-			response := server_http.Error{Reason: login.ErrInvalidCredentials.Error()}
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(response)
 		default:
 			response := server_http.Error{Reason: "internal server error"}
 			w.WriteHeader(http.StatusInternalServerError)
@@ -66,7 +62,7 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	
+
 	response := Response{Token: token}
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(response)

--- a/pkg/gateways/http/login/login.go
+++ b/pkg/gateways/http/login/login.go
@@ -32,7 +32,7 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.Header().Add("Content-Type", server_http.JSONContentType)
 		response := server_http.Error{Reason: "invalid request body"}
-		log.WithError(err).Error("error decoding body")
+		log.WithError(err).Error("error while decoding the body")
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(response)
 		return
@@ -66,5 +66,5 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 	response := Response{Token: token}
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(response)
-	log.Info("token created successfully")
+	log.Info("token was created successfully")
 }

--- a/pkg/gateways/http/login/login.go
+++ b/pkg/gateways/http/login/login.go
@@ -52,7 +52,7 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(response)
 		case errors.Is(err, login.ErrInvalidCPF):
-			response := server_http.Error{Reason: login.ErrInvalidCPF.Error()}
+			response := server_http.Error{Reason: login.ErrInvalidCredentials.Error()}
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(response)
 		case errors.Is(err, login.ErrInvalidSecret):

--- a/pkg/gateways/http/login/login.go
+++ b/pkg/gateways/http/login/login.go
@@ -22,6 +22,10 @@ type Response struct {
 
 func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 	log := h.logger
+	log.WithFields(logrus.Fields{
+		"route":  r.URL.Path,
+		"method": r.Method,
+	}).Info("login attempt realized")
 	var request Request
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {

--- a/pkg/gateways/http/login/login.go
+++ b/pkg/gateways/http/login/login.go
@@ -52,7 +52,7 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(response)
 		case errors.Is(err, login.ErrInvalidCPF):
-			response := server_http.Error{Reason: login.ErrInvalidCredentials.Error()}
+			response := server_http.Error{Reason: login.ErrInvalidCPF.Error()}
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(response)
 		case errors.Is(err, login.ErrInvalidSecret):

--- a/pkg/gateways/http/login/login.go
+++ b/pkg/gateways/http/login/login.go
@@ -21,11 +21,10 @@ type Response struct {
 }
 
 func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
-	log := h.logger
-	log.WithFields(logrus.Fields{
+	log := h.logger.WithFields(logrus.Fields{
 		"route":  r.URL.Path,
 		"method": r.Method,
-	}).Info("login attempt realized")
+	})
 
 	var request Request
 	err := json.NewDecoder(r.Body).Decode(&request)

--- a/pkg/gateways/http/login/login.go
+++ b/pkg/gateways/http/login/login.go
@@ -67,7 +67,5 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 	response := Response{Token: token}
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(response)
-	log.WithFields(logrus.Fields{
-		"token": response.Token,
-	}).Info("token created successfully")
+	log.Info("token created successfully")
 }

--- a/pkg/gateways/http/login/login.go
+++ b/pkg/gateways/http/login/login.go
@@ -56,7 +56,7 @@ func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(response)
 		case errors.Is(err, login.ErrInvalidSecret):
-			response := server_http.Error{Reason: login.ErrInvalidSecret.Error()}
+			response := server_http.Error{Reason: login.ErrInvalidCredentials.Error()}
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(response)
 		default:

--- a/pkg/gateways/http/login/login.go
+++ b/pkg/gateways/http/login/login.go
@@ -1,0 +1,69 @@
+package login
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/daniel1sender/Desafio-API/pkg/domain/accounts"
+	"github.com/daniel1sender/Desafio-API/pkg/domain/login"
+	server_http "github.com/daniel1sender/Desafio-API/pkg/gateways/http"
+	"github.com/sirupsen/logrus"
+)
+
+type Request struct {
+	Cpf    string `json:"cpf"`
+	Secret string `json:"secret"`
+}
+
+type Response struct {
+	Token string `json:"token"`
+}
+
+func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
+	log := h.logger
+	var request Request
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		w.Header().Add("Content-Type", server_http.JSONContentType)
+		response := server_http.Error{Reason: "invalid request body"}
+		log.WithError(err).Error("error decoding body")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+	w.Header().Add("Content-Type", server_http.JSONContentType)
+	token, err := h.UseCase.Login(r.Context(), request.Cpf, request.Secret)
+	if err != nil {
+		log.WithError(err).Error("login request failed")
+		switch {
+		case errors.Is(err, accounts.ErrAccountNotFound):
+			response := server_http.Error{Reason: accounts.ErrAccountNotFound.Error()}
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(response)
+		case errors.Is(err, login.ErrEmptySecret):
+			response := server_http.Error{Reason: login.ErrEmptySecret.Error()}
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(response)
+		case errors.Is(err, login.ErrInvalidCPF):
+			response := server_http.Error{Reason: login.ErrInvalidCPF.Error()}
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(response)
+		case errors.Is(err, login.ErrInvalidSecret):
+			response := server_http.Error{Reason: login.ErrInvalidSecret.Error()}
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(response)
+		default:
+			response := server_http.Error{Reason: "internal server error"}
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(response)
+		}
+		return
+	}
+	response := Response{Token: token}
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(response)
+	log.WithFields(logrus.Fields{
+		"token": response.Token,
+	}).Info("token created successfully")
+}

--- a/pkg/gateways/http/login/login_test.go
+++ b/pkg/gateways/http/login/login_test.go
@@ -32,12 +32,8 @@ func TestHandlerLogin(t *testing.T) {
 		var response Response
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
 
-		if newResponse.Code != http.StatusCreated {
-			t.Errorf("expected '%d' but got '%d'", http.StatusCreated, newResponse.Code)
-		}
-		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
-			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
-		}
+		assert.Equal(t, newResponse.Code, http.StatusCreated)
+		assert.Equal(t, newResponse.Header().Get("content-type"), server_http.JSONContentType)
 		assert.NotEmpty(t, response.Token)
 		assert.Equal(t, response.Token, useCase.Token)
 	})
@@ -53,16 +49,10 @@ func TestHandlerLogin(t *testing.T) {
 		var response server_http.Error
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
 
-		if newResponse.Code != http.StatusBadRequest {
-			t.Errorf("expected status '%d' but got '%d'", http.StatusBadRequest, newResponse.Code)
-		}
-		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
-			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
-		}
+		assert.Equal(t, newResponse.Code, http.StatusBadRequest)
+		assert.Equal(t, newResponse.Header().Get("content-type"), server_http.JSONContentType)
 		expected := "invalid request body"
-		if response.Reason != expected {
-			t.Errorf("expected '%s' but got '%s'", expected, response.Reason)
-		}
+		assert.Equal(t, response.Reason, expected)
 	})
 
 	t.Run("should return 404 and an error when account is not found", func(t *testing.T) {
@@ -76,15 +66,9 @@ func TestHandlerLogin(t *testing.T) {
 		var response server_http.Error
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
 
-		if newResponse.Code != http.StatusForbidden {
-			t.Errorf("expected '%d' but got '%d'", http.StatusForbidden, newResponse.Code)
-		}
-		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
-			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
-		}
-		if response.Reason != login.ErrInvalidCredentials.Error() {
-			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCredentials.Error(), response.Reason)
-		}
+		assert.Equal(t, newResponse.Code, http.StatusForbidden)
+		assert.Equal(t, newResponse.Header().Get("content-type"), server_http.JSONContentType)
+		assert.Equal(t, response.Reason, login.ErrInvalidCredentials.Error())
 	})
 
 	t.Run("should return 400 and an error when an empty secret is informed", func(t *testing.T) {
@@ -98,15 +82,9 @@ func TestHandlerLogin(t *testing.T) {
 		var response server_http.Error
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
 
-		if newResponse.Code != http.StatusBadRequest {
-			t.Errorf("expected '%d' but got '%d'", http.StatusNotFound, newResponse.Code)
-		}
-		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
-			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
-		}
-		if response.Reason != login.ErrEmptySecret.Error() {
-			t.Errorf("expected '%s' but got '%s'", login.ErrEmptySecret.Error(), response.Reason)
-		}
+		assert.Equal(t, newResponse.Code, http.StatusBadRequest)
+		assert.Equal(t, newResponse.Header().Get("content-type"), server_http.JSONContentType)
+		assert.Equal(t, response.Reason, login.ErrEmptySecret.Error())
 	})
 
 	t.Run("should return 400 and an error when the cpf informed doesn't have eleven digits", func(t *testing.T) {
@@ -120,15 +98,9 @@ func TestHandlerLogin(t *testing.T) {
 		var response server_http.Error
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
 
-		if newResponse.Code != http.StatusBadRequest {
-			t.Errorf("expected '%d' but got '%d'", http.StatusNotFound, newResponse.Code)
-		}
-		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
-			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
-		}
-		if response.Reason != login.ErrInvalidCPF.Error() {
-			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCPF.Error(), response.Reason)
-		}
+		assert.Equal(t, newResponse.Code, http.StatusBadRequest)
+		assert.Equal(t, newResponse.Header().Get("content-type"), server_http.JSONContentType)
+		assert.Equal(t, response.Reason, login.ErrInvalidCPF.Error())
 	})
 
 	t.Run("should return 400 and an error when secret informed is invalid", func(t *testing.T) {
@@ -142,15 +114,9 @@ func TestHandlerLogin(t *testing.T) {
 		var response server_http.Error
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
 
-		if newResponse.Code != http.StatusForbidden {
-			t.Errorf("expected '%d' but got '%d'", http.StatusForbidden, newResponse.Code)
-		}
-		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
-			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
-		}
-		if response.Reason != login.ErrInvalidCredentials.Error() {
-			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCredentials.Error(), response.Reason)
-		}
+		assert.Equal(t, newResponse.Code, http.StatusForbidden)
+		assert.Equal(t, newResponse.Header().Get("content-type"), server_http.JSONContentType)
+		assert.Equal(t, response.Reason, login.ErrInvalidCredentials.Error())
 	})
 
 	t.Run("should return 500 and an error when an unexpected error occourred", func(t *testing.T) {
@@ -165,15 +131,9 @@ func TestHandlerLogin(t *testing.T) {
 		var response server_http.Error
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
 
-		if newResponse.Code != http.StatusInternalServerError {
-			t.Errorf("expected '%d' but got '%d'", http.StatusInternalServerError, newResponse.Code)
-		}
-		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
-			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
-		}
+		assert.Equal(t, newResponse.Code, http.StatusInternalServerError)
+		assert.Equal(t, newResponse.Header().Get("content-type"), server_http.JSONContentType)
 		expectedReason := "internal server error"
-		if response.Reason != expectedReason {
-			t.Errorf("expected '%s' but got '%s'", expectedReason, response.Reason)
-		}
+		assert.Equal(t, response.Reason, expectedReason)
 	})
 }

--- a/pkg/gateways/http/login/login_test.go
+++ b/pkg/gateways/http/login/login_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestHandlerLogin(t *testing.T) {
 	log := logrus.NewEntry(logrus.New())
+
 	t.Run("should return 201 and the token created", func(t *testing.T) {
 		useCase := login.UseCaseMock{
 			Token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjM2Q3OGU2My1mYWQ5LTQ1ZTgtODI0OC1iOGNjMDc4ZDFiZGYiLCJleHAiOjE2NDg2Nzc5MDYsImlhdCI6MTY0ODY3NzYwNiwianRpIjoiZDNhNDYxMDctMDQzNi00ZmViLTk4YmItZGEzMTQzZmFiYWQyIn0.cN2-NOvwMwvEIKxBBVV-toJkmohkRDwppzCQs7XOqpA",
@@ -30,6 +31,7 @@ func TestHandlerLogin(t *testing.T) {
 		handler.Login(newResponse, newRequest)
 		var response Response
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
+		
 		if newResponse.Code != http.StatusCreated {
 			t.Errorf("expected '%d' but got '%d'", http.StatusCreated, newResponse.Code)
 		}
@@ -39,6 +41,7 @@ func TestHandlerLogin(t *testing.T) {
 		assert.NotEmpty(t, response.Token)
 		assert.Equal(t, response.Token, useCase.Token)
 	})
+
 	t.Run("should return 400 and an error when it failed to decode the request successfully", func(t *testing.T) {
 
 		useCase := login.UseCaseMock{}
@@ -49,6 +52,7 @@ func TestHandlerLogin(t *testing.T) {
 		h.Login(newResponse, newRequest)
 		var response server_http.Error
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
+
 		if newResponse.Code != http.StatusBadRequest {
 			t.Errorf("expected status '%d' but got '%d'", http.StatusBadRequest, newResponse.Code)
 		}
@@ -60,6 +64,7 @@ func TestHandlerLogin(t *testing.T) {
 			t.Errorf("expected '%s' but got '%s'", expected, response.Reason)
 		}
 	})
+
 	t.Run("should return 404 and an error when account is not found", func(t *testing.T) {
 		useCase := login.UseCaseMock{Error: accounts.ErrAccountNotFound}
 		handler := NewHandler(&useCase, log)
@@ -70,6 +75,7 @@ func TestHandlerLogin(t *testing.T) {
 		handler.Login(newResponse, newRequest)
 		var response server_http.Error
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
+
 		if newResponse.Code != http.StatusNotFound {
 			t.Errorf("expected '%d' but got '%d'", http.StatusNotFound, newResponse.Code)
 		}
@@ -80,6 +86,7 @@ func TestHandlerLogin(t *testing.T) {
 			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCredetials.Error(), response.Reason)
 		}
 	})
+
 	t.Run("should return 400 and an error when an empty secret is informed", func(t *testing.T) {
 		useCase := login.UseCaseMock{Error: login.ErrEmptySecret}
 		handler := NewHandler(&useCase, log)
@@ -90,6 +97,7 @@ func TestHandlerLogin(t *testing.T) {
 		handler.Login(newResponse, newRequest)
 		var response server_http.Error
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
+
 		if newResponse.Code != http.StatusBadRequest {
 			t.Errorf("expected '%d' but got '%d'", http.StatusNotFound, newResponse.Code)
 		}
@@ -100,6 +108,7 @@ func TestHandlerLogin(t *testing.T) {
 			t.Errorf("expected '%s' but got '%s'", login.ErrEmptySecret.Error(), response.Reason)
 		}
 	})
+
 	t.Run("should return 400 and an error when the cpf informed doesn't have eleven digits", func(t *testing.T) {
 		useCase := login.UseCaseMock{Error: login.ErrInvalidCPF}
 		handler := NewHandler(&useCase, log)
@@ -110,6 +119,7 @@ func TestHandlerLogin(t *testing.T) {
 		handler.Login(newResponse, newRequest)
 		var response server_http.Error
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
+
 		if newResponse.Code != http.StatusBadRequest {
 			t.Errorf("expected '%d' but got '%d'", http.StatusNotFound, newResponse.Code)
 		}
@@ -120,6 +130,7 @@ func TestHandlerLogin(t *testing.T) {
 			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCPF.Error(), response.Reason)
 		}
 	})
+
 	t.Run("should return 400 and an error when secret informed is invalid", func(t *testing.T) {
 		useCase := login.UseCaseMock{Error: login.ErrInvalidSecret}
 		handler := NewHandler(&useCase, log)
@@ -130,6 +141,7 @@ func TestHandlerLogin(t *testing.T) {
 		handler.Login(newResponse, newRequest)
 		var response server_http.Error
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
+
 		if newResponse.Code != http.StatusBadRequest {
 			t.Errorf("expected '%d' but got '%d'", http.StatusNotFound, newResponse.Code)
 		}
@@ -140,6 +152,7 @@ func TestHandlerLogin(t *testing.T) {
 			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidSecret.Error(), response.Reason)
 		}
 	})
+
 	t.Run("should return 500 and an error when an unexpected error occourred", func(t *testing.T){
 		ErrUnexpectedError := errors.New("unexpected error")
 		useCase := login.UseCaseMock{Error: ErrUnexpectedError}

--- a/pkg/gateways/http/login/login_test.go
+++ b/pkg/gateways/http/login/login_test.go
@@ -82,8 +82,8 @@ func TestHandlerLogin(t *testing.T) {
 		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
 			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
 		}
-		if response.Reason != login.ErrInvalidCredetials.Error() {
-			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCredetials.Error(), response.Reason)
+		if response.Reason != login.ErrInvalidCredentials.Error() {
+			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCredentials.Error(), response.Reason)
 		}
 	})
 

--- a/pkg/gateways/http/login/login_test.go
+++ b/pkg/gateways/http/login/login_test.go
@@ -148,8 +148,8 @@ func TestHandlerLogin(t *testing.T) {
 		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
 			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
 		}
-		if response.Reason != login.ErrInvalidSecret.Error() {
-			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidSecret.Error(), response.Reason)
+		if response.Reason != login.ErrInvalidCredentials.Error() {
+			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCredentials.Error(), response.Reason)
 		}
 	})
 

--- a/pkg/gateways/http/login/login_test.go
+++ b/pkg/gateways/http/login/login_test.go
@@ -126,8 +126,8 @@ func TestHandlerLogin(t *testing.T) {
 		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
 			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
 		}
-		if response.Reason != login.ErrInvalidCredentials.Error() {
-			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCredentials.Error(), response.Reason)
+		if response.Reason != login.ErrInvalidCPF.Error() {
+			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCPF.Error(), response.Reason)
 		}
 	})
 

--- a/pkg/gateways/http/login/login_test.go
+++ b/pkg/gateways/http/login/login_test.go
@@ -31,7 +31,7 @@ func TestHandlerLogin(t *testing.T) {
 		handler.Login(newResponse, newRequest)
 		var response Response
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
-		
+
 		if newResponse.Code != http.StatusCreated {
 			t.Errorf("expected '%d' but got '%d'", http.StatusCreated, newResponse.Code)
 		}
@@ -153,9 +153,9 @@ func TestHandlerLogin(t *testing.T) {
 		}
 	})
 
-	t.Run("should return 500 and an error when an unexpected error occourred", func(t *testing.T){
-		ErrUnexpectedError := errors.New("unexpected error")
-		useCase := login.UseCaseMock{Error: ErrUnexpectedError}
+	t.Run("should return 500 and an error when an unexpected error occourred", func(t *testing.T) {
+		unexpectedError := errors.New("unexpected error")
+		useCase := login.UseCaseMock{Error: unexpectedError}
 		handler := NewHandler(&useCase, log)
 		requestBody := Request{"12345678910", "123"}
 		request, _ := json.Marshal(requestBody)

--- a/pkg/gateways/http/login/login_test.go
+++ b/pkg/gateways/http/login/login_test.go
@@ -126,8 +126,8 @@ func TestHandlerLogin(t *testing.T) {
 		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
 			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
 		}
-		if response.Reason != login.ErrInvalidCPF.Error() {
-			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCPF.Error(), response.Reason)
+		if response.Reason != login.ErrInvalidCredentials.Error() {
+			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCredentials.Error(), response.Reason)
 		}
 	})
 

--- a/pkg/gateways/http/login/login_test.go
+++ b/pkg/gateways/http/login/login_test.go
@@ -75,8 +75,8 @@ func TestHandlerLogin(t *testing.T) {
 		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
 			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
 		}
-		if response.Reason != accounts.ErrAccountNotFound.Error() {
-			t.Errorf("expected '%s' but got '%s'", accounts.ErrAccountNotFound.Error(), response.Reason)
+		if response.Reason != login.ErrInvalidCredetials.Error() {
+			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCredetials.Error(), response.Reason)
 		}
 	})
 	t.Run("should return 400 and an error when an empty secret is informed", func(t *testing.T) {

--- a/pkg/gateways/http/login/login_test.go
+++ b/pkg/gateways/http/login/login_test.go
@@ -76,8 +76,8 @@ func TestHandlerLogin(t *testing.T) {
 		var response server_http.Error
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
 
-		if newResponse.Code != http.StatusNotFound {
-			t.Errorf("expected '%d' but got '%d'", http.StatusNotFound, newResponse.Code)
+		if newResponse.Code != http.StatusForbidden {
+			t.Errorf("expected '%d' but got '%d'", http.StatusForbidden, newResponse.Code)
 		}
 		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
 			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
@@ -142,8 +142,8 @@ func TestHandlerLogin(t *testing.T) {
 		var response server_http.Error
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
 
-		if newResponse.Code != http.StatusBadRequest {
-			t.Errorf("expected '%d' but got '%d'", http.StatusNotFound, newResponse.Code)
+		if newResponse.Code != http.StatusForbidden {
+			t.Errorf("expected '%d' but got '%d'", http.StatusForbidden, newResponse.Code)
 		}
 		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
 			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))

--- a/pkg/gateways/http/login/login_test.go
+++ b/pkg/gateways/http/login/login_test.go
@@ -55,7 +55,7 @@ func TestHandlerLogin(t *testing.T) {
 		assert.Equal(t, response.Reason, expected)
 	})
 
-	t.Run("should return 404 and an error when account is not found", func(t *testing.T) {
+	t.Run("should return 404 and an error when the account is not found", func(t *testing.T) {
 		useCase := login.UseCaseMock{Error: accounts.ErrAccountNotFound}
 		handler := NewHandler(&useCase, log)
 		requestBody := Request{"12345678910", "123"}
@@ -103,7 +103,7 @@ func TestHandlerLogin(t *testing.T) {
 		assert.Equal(t, response.Reason, login.ErrInvalidCPF.Error())
 	})
 
-	t.Run("should return 400 and an error when secret informed is invalid", func(t *testing.T) {
+	t.Run("should return 400 and an error when the secret informed is invalid", func(t *testing.T) {
 		useCase := login.UseCaseMock{Error: login.ErrInvalidSecret}
 		handler := NewHandler(&useCase, log)
 		requestBody := Request{"12345678910", "123"}

--- a/pkg/gateways/http/login/login_test.go
+++ b/pkg/gateways/http/login/login_test.go
@@ -1,0 +1,142 @@
+package login
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daniel1sender/Desafio-API/pkg/domain/accounts"
+	"github.com/daniel1sender/Desafio-API/pkg/domain/login"
+	server_http "github.com/daniel1sender/Desafio-API/pkg/gateways/http"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandlerLogin(t *testing.T) {
+	log := logrus.NewEntry(logrus.New())
+	t.Run("should return 201 and the token created", func(t *testing.T) {
+		useCase := login.UseCaseMock{
+			Token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjM2Q3OGU2My1mYWQ5LTQ1ZTgtODI0OC1iOGNjMDc4ZDFiZGYiLCJleHAiOjE2NDg2Nzc5MDYsImlhdCI6MTY0ODY3NzYwNiwianRpIjoiZDNhNDYxMDctMDQzNi00ZmViLTk4YmItZGEzMTQzZmFiYWQyIn0.cN2-NOvwMwvEIKxBBVV-toJkmohkRDwppzCQs7XOqpA",
+			Error: nil,
+		}
+		handler := NewHandler(&useCase, log)
+		requestBody := Request{"12345678910", "123"}
+		request, _ := json.Marshal(requestBody)
+		newRequest, _ := http.NewRequest("POST", "/anyroute", bytes.NewReader(request))
+		newResponse := httptest.NewRecorder()
+		handler.Login(newResponse, newRequest)
+		var response Response
+		json.Unmarshal(newResponse.Body.Bytes(), &response)
+		if newResponse.Code != http.StatusCreated {
+			t.Errorf("expected '%d' but got '%d'", http.StatusCreated, newResponse.Code)
+		}
+		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
+			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
+		}
+		assert.NotEmpty(t, response.Token)
+		assert.Equal(t, response.Token, useCase.Token)
+	})
+	t.Run("should return 400 and an error when it failed to decode the request successfully", func(t *testing.T) {
+
+		useCase := login.UseCaseMock{}
+		h := NewHandler(&useCase, log)
+		b := []byte{}
+		newRequest, _ := http.NewRequest("POST", "/anyroute", bytes.NewReader(b))
+		newResponse := httptest.NewRecorder()
+		h.Login(newResponse, newRequest)
+		var response server_http.Error
+		json.Unmarshal(newResponse.Body.Bytes(), &response)
+		if newResponse.Code != http.StatusBadRequest {
+			t.Errorf("expected status '%d' but got '%d'", http.StatusBadRequest, newResponse.Code)
+		}
+		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
+			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
+		}
+		expected := "invalid request body"
+		if response.Reason != expected {
+			t.Errorf("expected '%s' but got '%s'", expected, response.Reason)
+		}
+	})
+	t.Run("should return 404 and an error when account is not found", func(t *testing.T) {
+		useCase := login.UseCaseMock{Error: accounts.ErrAccountNotFound}
+		handler := NewHandler(&useCase, log)
+		requestBody := Request{"12345678910", "123"}
+		request, _ := json.Marshal(requestBody)
+		newRequest, _ := http.NewRequest("POST", "/anyroute", bytes.NewReader(request))
+		newResponse := httptest.NewRecorder()
+		handler.Login(newResponse, newRequest)
+		var response server_http.Error
+		json.Unmarshal(newResponse.Body.Bytes(), &response)
+		if newResponse.Code != http.StatusNotFound {
+			t.Errorf("expected '%d' but got '%d'", http.StatusNotFound, newResponse.Code)
+		}
+		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
+			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
+		}
+		if response.Reason != accounts.ErrAccountNotFound.Error() {
+			t.Errorf("expected '%s' but got '%s'", accounts.ErrAccountNotFound.Error(), response.Reason)
+		}
+	})
+	t.Run("should return 400 and an error when an empty secret is informed", func(t *testing.T) {
+		useCase := login.UseCaseMock{Error: login.ErrEmptySecret}
+		handler := NewHandler(&useCase, log)
+		requestBody := Request{"12345678910", "123"}
+		request, _ := json.Marshal(requestBody)
+		newRequest, _ := http.NewRequest("POST", "/anyroute", bytes.NewReader(request))
+		newResponse := httptest.NewRecorder()
+		handler.Login(newResponse, newRequest)
+		var response server_http.Error
+		json.Unmarshal(newResponse.Body.Bytes(), &response)
+		if newResponse.Code != http.StatusBadRequest {
+			t.Errorf("expected '%d' but got '%d'", http.StatusNotFound, newResponse.Code)
+		}
+		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
+			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
+		}
+		if response.Reason != login.ErrEmptySecret.Error() {
+			t.Errorf("expected '%s' but got '%s'", login.ErrEmptySecret.Error(), response.Reason)
+		}
+	})
+	t.Run("should return 400 and an error when the cpf informed doesn't have eleven digits", func(t *testing.T) {
+		useCase := login.UseCaseMock{Error: login.ErrInvalidCPF}
+		handler := NewHandler(&useCase, log)
+		requestBody := Request{"12345678910", "123"}
+		request, _ := json.Marshal(requestBody)
+		newRequest, _ := http.NewRequest("POST", "/anyroute", bytes.NewReader(request))
+		newResponse := httptest.NewRecorder()
+		handler.Login(newResponse, newRequest)
+		var response server_http.Error
+		json.Unmarshal(newResponse.Body.Bytes(), &response)
+		if newResponse.Code != http.StatusBadRequest {
+			t.Errorf("expected '%d' but got '%d'", http.StatusNotFound, newResponse.Code)
+		}
+		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
+			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
+		}
+		if response.Reason != login.ErrInvalidCPF.Error() {
+			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidCPF.Error(), response.Reason)
+		}
+	})
+	t.Run("should return 400 and an error when secret informed is invalid", func(t *testing.T) {
+		useCase := login.UseCaseMock{Error: login.ErrInvalidSecret}
+		handler := NewHandler(&useCase, log)
+		requestBody := Request{"12345678910", "123"}
+		request, _ := json.Marshal(requestBody)
+		newRequest, _ := http.NewRequest("POST", "/anyroute", bytes.NewReader(request))
+		newResponse := httptest.NewRecorder()
+		handler.Login(newResponse, newRequest)
+		var response server_http.Error
+		json.Unmarshal(newResponse.Body.Bytes(), &response)
+		if newResponse.Code != http.StatusBadRequest {
+			t.Errorf("expected '%d' but got '%d'", http.StatusNotFound, newResponse.Code)
+		}
+		if newResponse.Header().Get("content-type") != server_http.JSONContentType {
+			t.Errorf("expected '%s' but got '%s'", server_http.JSONContentType, newResponse.Header().Get("content-type"))
+		}
+		if response.Reason != login.ErrInvalidSecret.Error() {
+			t.Errorf("expected '%s' but got '%s'", login.ErrInvalidSecret.Error(), response.Reason)
+		}
+	})
+}


### PR DESCRIPTION
Primeiramente, fiz alguns ajustes no use-case de login para cobrir todos os casos de erros que meu use-case pode retornar para meu handler, dessa forma criei novos erros sentinelas e os adicionei no tratamento de erros do use-case Login. Posteriormente, adicionei a interface necessária para comunicar a parte http com o meu use-case de login e, por último, a estrutura do handler junto ao seu construtor e sua implementação.  

As mudanças propostas são:
- [x] ajustes no use-case de login
- [x] handler de login com implementação e testes
