### PR TITLE
Fix: fix get accounts bug

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
 FROM golang:1.17
-LABEL Daniel Sender
+LABEL maintainer="Daniel Sender"
 WORKDIR /app
 
+COPY . .
 COPY go.mod go.sum ./
 RUN go mod download
 
-COPY . /app/
 RUN go build -o desafio
 CMD ./desafio

--- a/pkg/gateways/http/accounts/get_all.go
+++ b/pkg/gateways/http/accounts/get_all.go
@@ -23,18 +23,18 @@ type GetAccountsResponse struct {
 func (h Handler) GetAll(w http.ResponseWriter, r *http.Request) {
 
 	log := h.logger
-	
+
 	accountsList, err := h.useCase.GetAll(r.Context())
 	if len(accountsList) == 0 && err != nil {
 		var statusCode int
-		var responseError GetAccountsResponse
+		var responseError server_http.Error
 		switch {
-		case errors.Is(err, accounts.ErrAccountNotFound):
+		case errors.Is(err, accounts.ErrEmptyList):
 			statusCode = http.StatusNotFound
-			responseError = GetAccountsResponse{[]Account{}}
+			responseError = server_http.Error{Reason: accounts.ErrEmptyList.Error()}
 		default:
 			statusCode = http.StatusInternalServerError
-			responseError = GetAccountsResponse{[]Account{}}
+			responseError = server_http.Error{Reason: err.Error()}
 		}
 		_ = server_http.SendResponse(w, responseError, statusCode)
 		log.WithFields(logrus.Fields{
@@ -53,6 +53,6 @@ func (h Handler) GetAll(w http.ResponseWriter, r *http.Request) {
 	_ = server_http.SendResponse(w, listOfAccountsResponse, http.StatusOK)
 	log.WithFields(logrus.Fields{
 		"number_of_accounts": len(accountsList),
-		"status_code":    http.StatusOK,
+		"status_code":        http.StatusOK,
 	}).Info("accounts listed successfully")
 }

--- a/pkg/gateways/http/accounts/get_all_test.go
+++ b/pkg/gateways/http/accounts/get_all_test.go
@@ -2,6 +2,7 @@ package accounts
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -44,7 +45,7 @@ func TestHandlerGetAll(t *testing.T) {
 
 	t.Run("should return 404 and an empty list of accounts when no account was created", func(t *testing.T) {
 
-		useCase := accounts.UseCaseMock{List: []entities.Account{}, Error: accounts.ErrAccountNotFound}
+		useCase := accounts.UseCaseMock{List: []entities.Account{}, Error: accounts.ErrEmptyList}
 		newRequest, _ := http.NewRequest(http.MethodGet, "/accounts", nil)
 		newResponse := httptest.NewRecorder()
 
@@ -55,13 +56,14 @@ func TestHandlerGetAll(t *testing.T) {
 		var accountsList GetAccountsResponse
 		json.Unmarshal(newResponse.Body.Bytes(), &accountsList)
 
-		assert.Equal(t, newResponse.Code, http.StatusNotFound)
+		assert.Equal(t, http.StatusNotFound, newResponse.Code)
 		assert.Empty(t, accountsList.List)
 		assert.Equal(t, newResponse.Header().Get("content-type"), server_http.JSONContentType)
 	})
 
 	t.Run("should return 500 and an empty list of accounts when some error with database occur", func(t *testing.T) {
-		useCase := accounts.UseCaseMock{List: []entities.Account{}, Error: accounts.ErrEmptyList}
+		unexpectedError := errors.New("unexpected error")
+		useCase := accounts.UseCaseMock{List: []entities.Account{}, Error: unexpectedError}
 		newRequest, _ := http.NewRequest(http.MethodGet, "/accounts", nil)
 		newResponse := httptest.NewRecorder()
 

--- a/pkg/gateways/store/postgres/accounts/get_all.go
+++ b/pkg/gateways/store/postgres/accounts/get_all.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/daniel1sender/Desafio-API/pkg/domain/accounts"
 	"github.com/daniel1sender/Desafio-API/pkg/domain/entities"
-	"github.com/jackc/pgx/v4"
 )
 
 func (ar AccountRepository) GetAll(ctx context.Context) ([]entities.Account, error) {
@@ -14,9 +13,7 @@ func (ar AccountRepository) GetAll(ctx context.Context) ([]entities.Account, err
 	var user entities.Account
 
 	rows, err := ar.Query(ctx, "SELECT id, name, cpf, secret, balance, created_at FROM accounts")
-	if err == pgx.ErrNoRows {
-		return []entities.Account{}, accounts.ErrAccountNotFound
-	} else if err != nil {
+	if err != nil {
 		return []entities.Account{}, err
 	}
 


### PR DESCRIPTION
O principal intuito deste PR é consertar o seguinte na listagem de contas:
Quando a requisição de listagem de contas é feita, caso nenhuma conta tenha sido criada, a aplicação retornava status 500 (internal server error) erroneamente. Isso acontecia devido à implementação retornar o erro ErrEmptyList que não era reconhecido pelo Handler GetAll. Foram feitas as mudanças necessárias neste Handler para que ele passe a reconhecer esse erro e retornar uma mensagem ideal como resposta. 
Alguns detalhes foram melhorados no dockerfile, especificando corretamente o mantenedor da imagem docker da aplicação. 