### PR TITLE
chore: remove the test inappropriate dependency of the application

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
-	gotest.tools v2.2.0+incompatible
 )
 
 require (
@@ -29,7 +28,6 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect

--- a/pkg/gateways/http/accounts/create_test.go
+++ b/pkg/gateways/http/accounts/create_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/daniel1sender/Desafio-API/pkg/domain/entities"
 	server_http "github.com/daniel1sender/Desafio-API/pkg/gateways/http"
 	"github.com/sirupsen/logrus"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHandlerCreate(t *testing.T) {

--- a/pkg/gateways/http/accounts/get_balance_by_id_test.go
+++ b/pkg/gateways/http/accounts/get_balance_by_id_test.go
@@ -9,7 +9,7 @@ import (
 	accounts_usecase "github.com/daniel1sender/Desafio-API/pkg/domain/accounts"
 	server_http "github.com/daniel1sender/Desafio-API/pkg/gateways/http"
 	"github.com/sirupsen/logrus"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHandlerGetBalanceByID(t *testing.T) {
@@ -28,7 +28,7 @@ func TestHandlerGetBalanceByID(t *testing.T) {
 		var response GetBalanceByIdResponse
 		json.Unmarshal(newResponse.Body.Bytes(), &response)
 
-		assert.Equal(t, newResponse.Code, http.StatusOK )
+		assert.Equal(t, newResponse.Code, http.StatusOK)
 		assert.Equal(t, newResponse.Header().Get("content-type"), server_http.JSONContentType)
 		assert.Equal(t, response.Balance, expectedBalance)
 	})


### PR DESCRIPTION
Este PR tem como intuito a remoção de uma dependência inapropriada para esta aplicação.  A lib gotest.tools/assert, apesar de ter suporte ao assert que é usado nos testes, contém outras funcionalidades que não são utilizadas nesta aplicação, portanto, ela foi retirada do testes da aplicação.